### PR TITLE
Replace finfo_...() calls with mime_content_type() to avoid magic/int…

### DIFF
--- a/src/VCard.php
+++ b/src/VCard.php
@@ -190,10 +190,8 @@ class VCard
             }
 
             $value = base64_encode($value);
-
-            $finfo = finfo_open(FILEINFO_MIME_TYPE);
-            $mimetype = finfo_file($finfo, 'data://application/octet-stream;base64,' . $value);
-            finfo_close($finfo);
+            
+            $mimetype = mime_content_type($url);
 
             if (preg_match('/^image\//', $mimetype) !== 1) {
                 throw new VCardMediaException('Returned data aren\'t an image.');


### PR DESCRIPTION
…ernal database errors.

The error/warning: Warning: finfo::file(): Failed identify data 0:no magic files loaded. (on line 195)

As an added bonus we're replacing three lines of code with just one.

There is an existing bug report here: https://bugs.php.net/bug.php?id=69773
